### PR TITLE
fix(contact-form): catch typo'd free-email domains and show inline validation errors

### DIFF
--- a/src/app/Chat-Bet/pages/main-page/main-page.component.html
+++ b/src/app/Chat-Bet/pages/main-page/main-page.component.html
@@ -670,7 +670,7 @@
         />
       </div>
       <div
-        *ngIf="form.get('email')?.hasError('forbiddenDomain') && form.get('email')?.touched"
+        *ngIf="form.get('email')?.invalid && form.get('email')?.touched"
         style="color: red; font-size: 0.9em"
       >
         {{ 'contactUs.form.error' | translate }}

--- a/src/app/validators/validationInstitucional.ts
+++ b/src/app/validators/validationInstitucional.ts
@@ -1,26 +1,29 @@
 import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
 
 export function validationInstitucional(
-  blacklistedDomains: string[], 
+  blacklistedDomains: string[],
   strictDotCom: boolean = false
 ): ValidatorFn {
+  const blacklistedRoots = blacklistedDomains.map((domain) => domain.split('.')[0]);
+
   return (control: AbstractControl): ValidationErrors | null => {
     if (!control.value) {
-      return null; 
+      return null;
     }
 
     const email = control.value.toLowerCase().trim();
     const emailParts = email.split('@');
 
-    if (emailParts.length !== 2) {
+    if (emailParts.length !== 2 || !emailParts[1]) {
       return { invalidFormat: true };
     }
 
     const domain = emailParts[1];
+    const domainRoot = domain.split('.')[0];
 
-    // 1. Filtrar dominios de correo gratuito (Blacklist)
-    if (blacklistedDomains.includes(domain)) {
-      return { forbiddenDomain: true }; 
+    // 1. Filtrar dominios de correo gratuito, incluyendo typos/variantes de TLD (Blacklist)
+    if (blacklistedDomains.includes(domain) || blacklistedRoots.includes(domainRoot)) {
+      return { forbiddenDomain: true };
     }
 
     // 2. Condición restrictiva: Solo permitir terminación .com

--- a/src/assets/languages/en.json
+++ b/src/assets/languages/en.json
@@ -377,7 +377,7 @@
               "message": "Message",
               "submit": "Send Message",
               "select": "Select one option",
-              "error": "Please enter a valid email",
+              "error": "Please enter a valid corporate email",
               "thanksmessage": "Thank you for contacting us!",
               "interestLabel": "I’m an Operator Interested in Using ChatBet",
               "specify": "Please specify here",

--- a/src/assets/languages/es.json
+++ b/src/assets/languages/es.json
@@ -378,7 +378,7 @@
       "message": "¿Algún comentario adicional? (Opcional)",
       "select": "Selecciona",
       "thanksmessage": "Gracias por contactarnos. Estamos construyendo algo poderoso y trabajamos con una lista curada de socios. Si tu perfil se alinea con nuestras prioridades actuales, alguien de nuestro equipo se pondrá en contacto contigo pronto.",
-      "error": "Unicamente se permiten correos corporativos",
+      "error": "Por favor, ingresa un correo corporativo válido",
       "submit": "Enviar info",
       "interestLabel": "Soy un operador interesado en usar ChatBet",
       "specify": "Por favor, especifique aquí",


### PR DESCRIPTION
## Summary
- The corporate-email blacklist in `validationInstitucional.ts` only matched exact domain strings, so typo'd/truncated variants of free providers (e.g. `gmail.co` instead of `gmail.com`) slipped through both `Validators.email` and the blacklist check — confirmed with the screenshot on the ClickUp ticket. Now it also matches on the domain's root label (part before the first dot), so TLD typos of any blacklisted provider are caught too.
- The inline red error under the email field only rendered for the `forbiddenDomain` error, so `required`/format errors showed no per-field feedback (only a generic toast on submit). It now renders for any invalid state once the field is touched.
- English copy updated from "Please enter a valid email" to "Please enter a valid corporate email"; Spanish copy updated to match.

Out of scope (explicit call): real email-existence/deliverability verification (MX/SMTP check) was intentionally left out — it requires a paid third-party service plus a backend proxy to hide the API key, and was scoped as a separate future project.

ClickUp: https://app.clickup.com/t/86ajrvp1h

## Test plan
- [ ] `test@gmail.com` → blocked, shows "Please enter a valid corporate email"
- [ ] `test@gmail.co` → blocked (this was the reported bug — previously passed silently)
- [ ] `test@acmecorp.com` (real corporate domain) → passes, no error
- [ ] Leave email empty and blur/submit → inline error shows under the field
- [ ] Malformed email with no `@` → inline error shows under the field
- [ ] `npm run build` passes clean (verified locally, only pre-existing unrelated `lottie-web` CommonJS warning)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contact form email validation to display errors for all invalid, touched email fields.
  * Expanded detection of blocked email domains and domain variants.
  * Strengthened handling of malformed or incomplete email addresses.

* **Localization**
  * Updated English and Spanish validation messages to clearly request a valid corporate email address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->