### PR TITLE
fix: require real TLD structure in corporate-email validator

### DIFF
--- a/src/app/validators/validationInstitucional.ts
+++ b/src/app/validators/validationInstitucional.ts
@@ -19,14 +19,20 @@ export function validationInstitucional(
     }
 
     const domain = emailParts[1];
+
+    // 1. Formato: el dominio debe tener un TLD real (al menos un punto y 2+ letras después), sin importar cuál (.com, .io, .gg, etc.)
+    if (!/^[a-z0-9-]+(\.[a-z0-9-]+)*\.[a-z]{2,}$/.test(domain)) {
+      return { invalidFormat: true };
+    }
+
     const domainRoot = domain.split('.')[0];
 
-    // 1. Filtrar dominios de correo gratuito, incluyendo typos/variantes de TLD (Blacklist)
+    // 2. Filtrar dominios de correo gratuito, incluyendo typos/variantes de TLD (Blacklist)
     if (blacklistedDomains.includes(domain) || blacklistedRoots.includes(domainRoot)) {
       return { forbiddenDomain: true };
     }
 
-    // 2. Condición restrictiva: Solo permitir terminación .com
+    // 3. Condición restrictiva: Solo permitir terminación .com
     if (strictDotCom && !domain.endsWith('.com')) {
       return { forbiddenDomain: true }; 
     }


### PR DESCRIPTION
## Summary
- Follow-up to #13 (CU-86ajrvp1h): `plata@gmai` was accepted as a valid corporate email during testing — no dot/TLD in the domain at all, so neither `Validators.email` nor the blacklist root-match caught it.
- Adds a structural check requiring `domain.tld` (any TLD — `.com`, `.io`, `.gg`, `.co`, etc. — so legitimate client domains still pass) before the free-provider blacklist check runs.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Regex sanity-checked against `gmai` (reject), `gmail.com`/`cliente.io`/`cliente.gg`/`empresa.co`/`sub.empresa.io` (accept), `empresa.c` single-char TLD (reject)
- [ ] Manual retest of the contact form with `plata@gmai` once deployed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email validation by rejecting domains without a valid structure, including domains missing a dot or a properly formatted top-level domain.
  * Preserved existing checks for blocked domains and restrictive `.com` requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->